### PR TITLE
apiからの年賀状追加でもshareIdを自動生成する

### DIFF
--- a/src/api/card/content-types/card/schema.json
+++ b/src/api/card/content-types/card/schema.json
@@ -40,7 +40,7 @@
     "shareId": {
       "type": "customField",
       "customField": "plugin::strapi-advanced-uuid.uuid",
-      "required": true
+      "required": false
     }
   }
 }


### PR DESCRIPTION
- shareIdをrequiredにしておくと、コンソールでは未入力でも自動補完が効くものの、apiからのリクエストを弾いてしまうので、requiredを外した