### PR TITLE
速達用のフィールドを追加

### DIFF
--- a/src/api/card/content-types/card/schema.json
+++ b/src/api/card/content-types/card/schema.json
@@ -41,6 +41,11 @@
       "type": "customField",
       "customField": "plugin::strapi-advanced-uuid.uuid",
       "required": false
+    },
+    "isExpress": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }


### PR DESCRIPTION
- `isExpress: boolean` を追加
- 既存のCardは`isExpress = null`になる
  - おそらく問題は出ないけど、想定する環境と合わせる意味では`false`か`true`に手動で置き換えてもいいかも
- recievedCardのupdate権限を追加する必要がある
  <img width="573" alt="スクリーンショット 2024-11-04 20 00 07" src="https://github.com/user-attachments/assets/1baf5344-605b-40a7-b909-406026bfa5ee">
