### PR TITLE
配達管理を時刻ベースにする

### DIFF
--- a/src/api/card/content-types/card/schema.json
+++ b/src/api/card/content-types/card/schema.json
@@ -42,10 +42,9 @@
       "customField": "plugin::strapi-advanced-uuid.uuid",
       "required": false
     },
-    "isExpress": {
-      "type": "boolean",
-      "default": false,
-      "required": true
+    "deliveredAt": {
+      "required": true,
+      "type": "datetime"
     }
   }
 }


### PR DESCRIPTION
- これまで、`isExpress`を保持して、受け取り側で配達済みか判定していた
- これを、送信側で「届くべき日時」のタイムスタンプを付与するように変更する