### PR TITLE
achievementコレクションのtypo

### DIFF
--- a/src/api/achievement/content-types/achievement/schema.json
+++ b/src/api/achievement/content-types/achievement/schema.json
@@ -17,7 +17,7 @@
       "relation": "oneToOne",
       "target": "plugin::users-permissions.user"
     },
-    "AchievementKey": {
+    "achievementKey": {
       "type": "string",
       "required": true
     }


### PR DESCRIPTION
フィールド名がパスカルケースになっていたのでキャメルケースに変更